### PR TITLE
Delete 'Getting Started' section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
-## Getting Started
-
 First, run the development server:
 
 ```bash


### PR DESCRIPTION
Removed 'Getting Started' section from README